### PR TITLE
Fixes Crafting

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2760,10 +2760,17 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     if (!this.spawned || !this.isAlive()) {
                         break;
                     }
-                    this.craftingType = CRAFTING_SMALL;
 
                     InteractPacket interactPacket = (InteractPacket) packet;
 
+                    if(interactPacket.action == InteractPacket.ACTION_MOUSEOVER){
+                        if(interactPacket.target == 0){
+                            break;
+                        }
+                    }
+                    
+                    this.craftingType = CRAFTING_SMALL;
+                    
                     Entity targetEntity = this.level.getEntity(interactPacket.target);
 
                     if (targetEntity == null || !this.isAlive() || !targetEntity.isAlive()) {


### PR DESCRIPTION
interactPacket.ACTION_MOUSEOVER is sent multiple times which instantly
cancels any craftingType as craftingType is set to  CRAFTING_SMALL every
time the Interact_Packet is sent to the server. If a player walks past
the crafting player is possibly will cause the bug to happen again.
Maybe a long term fix is to only set the craftingType in a valid action
like ACTION_LEFT_CLICK/ACTION_RIGHT_CLICK/ACTION_VEHICLE_EXIT ?